### PR TITLE
Fix clear button to reset chat history

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ with gr.Blocks(css=custom_css, theme=gr.themes.Soft(primary_hue="purple")) as de
         return "", chat_history
 
     msg.submit(respond, [msg, chatbot], [msg, chatbot])
-    clear.click(lambda: None, None, chatbot, queue=False)
+    clear.click(lambda: [], None, chatbot, queue=False)
 
 if __name__ == "__main__":
     demo.launch()


### PR DESCRIPTION
### Motivation
- Ensure the Clear button immediately clears the visible conversation by returning an empty history to the chat component.
- The previous handler returned `None`, which did not reset the `chatbot` contents as intended.
- Pressing Clear should remove all messages from the UI to avoid confusing stale state.
- Change aligns the callback return value with Gradio `Chatbot` expectations.

### Description
- Updated `app.py` to change `clear.click(lambda: None, None, chatbot, queue=False)` to `clear.click(lambda: [], None, chatbot, queue=False)`.
- The handler now returns an empty list to the `chatbot` component so displayed messages are cleared immediately.
- No other UI logic or components were modified.
- Modified file: `app.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ad57a104832e886dd80f449674e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the clear button behavior to properly reset chat history in the chatbot component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->