### PR TITLE
Use chat template for prompt construction and add fallback for message formatting errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,8 +43,25 @@ def chat_function(message, history):
         messages.append({"role": "assistant", "content": assistant_msg})
     
     messages.append({"role": "user", "content": message})
-    
-    output = pipe(messages, **generation_args)
+
+    try:
+        prompt = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+    except (TypeError, ValueError):
+        safe_messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": str(message)},
+        ]
+        prompt = tokenizer.apply_chat_template(
+            safe_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    output = pipe(prompt, **generation_args)
     response = output[0]['generated_text']
     return response
 


### PR DESCRIPTION
### Motivation
- Replace passing a list of chat messages directly to the generation `pipe` with a single prompt string built from the chat template to match tokenizer expectations.
- Ensure generation remains stable when message formatting or types cause the template application to fail.
- Simplify downstream generation input by using a single string prompt rather than a message list.

### Description
- Use `tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)` to construct a single prompt before calling `pipe`.
- Catch `TypeError` and `ValueError` from template application and fallback to a minimal `safe_messages` payload containing only the `SYSTEM_PROMPT` and the user `message`.
- Pass the constructed `prompt` (string) into `pipe` instead of the original `messages` list so the model receives the expected input format.

### Testing
- No automated tests were executed as part of this change.
- Basic local execution was the intended manual validation path but not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ad540090832eaf7bef45af7e3510)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced prompt processing reliability with improved error handling and fallback mechanisms for better system stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->