### PR TITLE
Default chat history to empty list and update clear button

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ SYSTEM_PROMPT = """
 """
 
 def chat_function(message, history):
+    history = history or []
     messages = [{"role": "system", "content": SYSTEM_PROMPT}]
     for user_msg, assistant_msg in history:
         messages.append({"role": "user", "content": user_msg})
@@ -66,12 +67,13 @@ with gr.Blocks(css=custom_css, theme=gr.themes.Soft(primary_hue="purple")) as de
     clear = gr.Button("مسح المحادثة")
 
     def respond(message, chat_history):
+        chat_history = chat_history or []
         bot_message = chat_function(message, chat_history)
         chat_history.append((message, bot_message))
         return "", chat_history
 
     msg.submit(respond, [msg, chatbot], [msg, chatbot])
-    clear.click(lambda: None, None, chatbot, queue=False)
+    clear.click(lambda: [], None, chatbot, queue=False)
 
 if __name__ == "__main__":
     demo.launch()


### PR DESCRIPTION
### Motivation
- Prevent crashes when `history` is `None` by ensuring handlers always have a list to iterate. 
- Keep the `chatbot` history type consistent when the clear button is used. 

### Description
- Add `history = history or []` at the start of `chat_function` to guard against `None` values. 
- Add `chat_history = chat_history or []` in the `respond` handler to ensure the UI handler always uses a list. 
- Change `clear.click` to return `[]` instead of `None` so the chatbot history remains a list after clearing. 

### Testing
- No automated tests were executed for this change. 
- Manual run not recorded, so behavior should be verified in the running UI to confirm no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959179b4cf8832eab90e9c909a2d99e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed chat history handling to properly initialize empty conversation states instead of null values.
  * Improved clear button functionality to correctly reset the chat conversation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->