### PR TITLE
Limit chat history to recent turns

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,8 +35,11 @@ SYSTEM_PROMPT = """
 المخرجات: اجعلي الردود مختصرة عند اللزوم، ومنظمة بعناوين ونقاط.
 """
 
+MAX_TURNS = 10
+
 def chat_function(message, history):
     messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    history = history[-MAX_TURNS:]  # حصر عدد الأزواج السابقة لآخر N محادثات
     for user_msg, assistant_msg in history:
         messages.append({"role": "user", "content": user_msg})
         messages.append({"role": "assistant", "content": assistant_msg})


### PR DESCRIPTION
### Motivation
- Keep the model input within reasonable token limits by capping prior conversation turns.
- Reduce unnecessary compute and latency when building the prompt for generation.
- Avoid unbounded growth of context that could lead to memory or prompt-length issues.

### Description
- Add a `MAX_TURNS = 10` constant near the `SYSTEM_PROMPT` definition.
- Trim the incoming `history` in `chat_function` using `history = history[-MAX_TURNS:]` before assembling `messages`, with an inline comment documenting the limit.
- Preserve the existing message assembly and text-generation flow using the configured `pipeline` and `generation_args`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959179b6540832ebdff284f9046ef58)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Conversation history is now limited to the most recent exchanges.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->