### PR TITLE
Use chat template prompt for generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,8 +43,15 @@ def chat_function(message, history):
     
     messages.append({"role": "user", "content": message})
     
-    output = pipe(messages, **generation_args)
-    response = output[0]['generated_text']
+    prompt = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    output = pipe(prompt, **generation_args)
+    response = output[0]["generated_text"]
+    if response.startswith(prompt):
+        response = response[len(prompt):]
     return response
 
 # تصميم الواجهة CSS


### PR DESCRIPTION
### Motivation
- Ensure the model receives a proper text prompt formatted by the tokenizer before generation by using the chat template via `tokenizer.apply_chat_template`.
- Pass a single prompt string to the text generation `pipe` instead of a list of message dicts for compatibility with the generation pipeline.
- Avoid returning the original prompt together with the model output by trimming the prompt from the generated text so only the assistant reply is returned.

### Description
- Build `prompt` in `chat_function` using `tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)`.
- Call `pipe` with the resulting `prompt` and existing `generation_args` instead of passing the `messages` list.
- Trim the `prompt` from the start of `response` when present by checking `if response.startswith(prompt): response = response[len(prompt):]`.
- Changes are limited to `chat_function` in `app.py` and preserve previous generation settings.

### Testing
- No automated tests were executed for this change.
- Automated test status is therefore unknown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695917cec7e4832e813ab2b00054ad07)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal prompt construction and response processing for chat interactions to improve generation consistency and accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->