### PR TITLE
Return empty list from clear button to reset chat

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ with gr.Blocks(css=custom_css, theme=gr.themes.Soft(primary_hue="purple")) as de
         return "", chat_history
 
     msg.submit(respond, [msg, chatbot], [msg, chatbot])
-    clear.click(lambda: None, None, chatbot, queue=False)
+    clear.click(lambda: [], None, chatbot, queue=False)
 
 if __name__ == "__main__":
     demo.launch()


### PR DESCRIPTION
### Motivation
- Ensure the clear button actually resets the chat history by returning an empty list instead of `None` so the `Chatbot` component is cleared.
- Make the clear action consistent with Gradio output expectations for the `Chatbot` component.

### Description
- Updated `app.py` to change the clear button callback from returning `None` to returning an empty list `[]` in the call to `clear.click`.
- The change targets the call `clear.click(lambda: [], None, chatbot, queue=False)` to reset the `chatbot` contents.
- No changes were made to reset the input `Textbox`; that optional behavior was not implemented.

### Testing
- No automated tests were executed as part of this change.
- A manual run was not recorded in automated logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695917df1824832e8f76286e7bfa2c58)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the clear button to properly reset the chatbot output display. The button now correctly clears all previous messages from the conversation instead of failing to take action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->